### PR TITLE
Support Slack 2.0 plugin

### DIFF
--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -32,6 +32,7 @@ Example::
 """
 
 import logging
+import pkg_resources
 import xml.etree.ElementTree as XML
 
 from jenkins_jobs.errors import InvalidAttributeError
@@ -639,9 +640,10 @@ def slack(parser, xml_parent, data):
     """yaml: slack
     Requires the Jenkins :jenkins-wiki:`Slack Plugin <Slack+Plugin>`
 
-    As the Slack Plugin itself requires a publisher aswell as properties
-    please note that you have to add the publisher to your job configuration
-    aswell.
+    When using Slack Plugin version < 2.0, Slack Plugin itself requires a
+    publisher aswell as properties please note that you have to add the
+    publisher to your job configuration aswell. When using Slack Plugin
+    version >= 2.0, you should only configure the publisher.
 
     :arg bool notify-start: Send notification when the job starts
         (default: False)
@@ -674,6 +676,16 @@ def slack(parser, xml_parent, data):
         if isinstance(value, bool):
             value = str(value).lower()
         XML.SubElement(elem, name).text = value
+
+    logger = logging.getLogger(__name__)
+
+    plugin_info = parser.registry.get_plugin_info('Slack Notification Plugin')
+    plugin_ver = pkg_resources.parse_version(plugin_info.get('version', "0"))
+
+    if plugin_ver >= pkg_resources.parse_version("2.0"):
+        logger.warn(
+            "properties section is not used with plugin version >= 2.0",
+        )
 
     mapping = (
         ('notify-start', 'startNotification', False),

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -5667,8 +5667,10 @@ def slack(parser, xml_parent, data):
 
     Requires the Jenkins :jenkins-wiki:`Slack Plugin <Slack+Plugin>`
 
-    As the Slack Plugin itself requires a publisher aswell as properties
-    please note that you have to create those too.
+    When using Slack Plugin version < 2.0, Slack Plugin itself requires a
+    publisher aswell as properties please note that you have to create those
+    too.  When using Slack Plugin version >= 2.0, you should only configure the
+    publisher.
 
     :arg str team-domain: Your team's domain at slack. (default: '')
     :arg str auth-token: The integration token to be used when sending
@@ -5677,14 +5679,62 @@ def slack(parser, xml_parent, data):
         (default: '/')
     :arg str room: A comma seperated list of rooms / channels to post the
         notifications to. (default: '')
-    Example:
+    :arg bool notify-start: Send notification when the job starts (>=2.0).
+        (default: False)
+    :arg bool notify-success: Send notification on success (>=2.0).
+        (default: False)
+    :arg bool notify-aborted: Send notification when job is aborted (>=2.0).
+        (default: False)
+    :arg bool notify-not-built: Send notification when job set to NOT_BUILT
+        status (>=2.0). (default: False)
+    :arg bool notify-unstable: Send notification when job becomes unstable
+        (>=2.0). (default: False)
+    :arg bool notify-failure: Send notification when job fails for the first
+        time (previous build was a success) (>=2.0).  (default: False)
+    :arg bool notifiy-back-to-normal: Send notification when job is succeeding
+        again after being unstable or failed (>=2.0). (default: False)
+    :arg bool notify-repeated-failure: Send notification when job fails
+        successively (previous build was also a failure) (>=2.0).
+        (default: False)
+    :arg bool include-test-summary: Include the test summary (>=2.0).
+        (default: False)
+    :arg str commit-info-choice: What commit information to include into
+        notification message, "NONE" includes nothing about commits, "AUTHORS"
+        includes commit list with authors only, and "AUTHORS_AND_TITLES"
+        includes commit list with authors and titles (>=2.0). (default: "NONE")
+    :arg bool include-custom-message: Include a custom message into the
+        notification (>=2.0). (default: False)
+    :arg str custom-message: Custom message to be included (>=2.0).
+        (default: '')
+
+    Example (version < 2.0):
 
     .. literalinclude::
         /../../tests/publishers/fixtures/slack001.yaml
         :language: yaml
+
+    Minimal example (version >= 2.0):
+
+    .. literalinclude::
+        /../../tests/publishers/fixtures/slack003.yaml
+        :language: yaml
+
+    Full example (version >= 2.0):
+
+    .. literalinclude::
+        /../../tests/publishers/fixtures/slack004.yaml
+        :language: yaml
+
     """
     def _add_xml(elem, name, value=''):
+        if isinstance(value, bool):
+            value = str(value).lower()
         XML.SubElement(elem, name).text = value
+
+    logger = logging.getLogger(__name__)
+
+    plugin_info = parser.registry.get_plugin_info('Slack Notification Plugin')
+    plugin_ver = pkg_resources.parse_version(plugin_info.get('version', "0"))
 
     mapping = (
         ('team-domain', 'teamDomain', ''),
@@ -5692,18 +5742,61 @@ def slack(parser, xml_parent, data):
         ('build-server-url', 'buildServerUrl', '/'),
         ('room', 'room', ''),
     )
+    mapping_20 = (
+        ('notify-start', 'startNotification', False),
+        ('notify-success', 'notifySuccess', False),
+        ('notify-aborted', 'notifyAborted', False),
+        ('notify-not-built', 'notifyNotBuilt', False),
+        ('notify-unstable', 'notifyUnstable', False),
+        ('notify-failure', 'notifyFailure', False),
+        ('notify-back-to-normal', 'notifyBackToNormal', False),
+        ('notify-repeated-failure', 'notifyRepeatedFailure', False),
+        ('include-test-summary', 'includeTestSummary', False),
+        ('commit-info-choice', 'commitInfoChoice', 'NONE'),
+        ('include-custom-message', 'includeCustomMessage', False),
+        ('custom-message', 'customMessage', ''),
+    )
+
+    commit_info_choices = ['NONE', 'AUTHORS', 'AUTHORS_AND_TITLES']
 
     slack = XML.SubElement(
         xml_parent,
         'jenkins.plugins.slack.SlackNotifier',
     )
 
+    if plugin_ver >= pkg_resources.parse_version("2.0"):
+        mapping = mapping + mapping_20
+
+    if plugin_ver < pkg_resources.parse_version("2.0"):
+        for yaml_name, _, default_value in mapping:
+            # All arguments that don't have a default value are mandatory for
+            # the plugin to work as intended.
+            if not data.get(yaml_name, default_value):
+                raise MissingAttributeError(yaml_name)
+
+        for yaml_name, _, _ in mapping_20:
+            if yaml_name in data:
+                logger.warn(
+                    "'%s' is invalid with plugin version < 2.0, ignored",
+                    yaml_name,
+                )
+
     for yaml_name, xml_name, default_value in mapping:
         value = data.get(yaml_name, default_value)
-        # All arguments that don't have a default value are mandatory for the
-        # plugin to work as intended.
-        if not value:
-            raise MissingAttributeError(yaml_name)
+
+        # 'commit-info-choice' is enumerated type
+        if yaml_name == 'commit-info-choice':
+            if value not in commit_info_choices:
+                raise InvalidAttributeError(
+                    yaml_name, value, commit_info_choices,
+                )
+
+        # Ensure that custom-message is set when include-custom-message is set
+        # to true.
+        if yaml_name == 'include-custom-message' and data is False:
+            if not data.get('custom-message', ''):
+                raise MissingAttributeError('custom-message')
+
         _add_xml(slack, xml_name, value)
 
 

--- a/tests/publishers/fixtures/slack003.plugins_info.yaml
+++ b/tests/publishers/fixtures/slack003.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Slack Notification Plugin'
+  shortName: 'slack'
+  version: "2.0"

--- a/tests/publishers/fixtures/slack003.xml
+++ b/tests/publishers/fixtures/slack003.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <publishers>
+    <jenkins.plugins.slack.SlackNotifier>
+      <teamDomain/>
+      <authToken/>
+      <buildServerUrl>/</buildServerUrl>
+      <room/>
+      <startNotification>false</startNotification>
+      <notifySuccess>false</notifySuccess>
+      <notifyAborted>false</notifyAborted>
+      <notifyNotBuilt>false</notifyNotBuilt>
+      <notifyUnstable>false</notifyUnstable>
+      <notifyFailure>false</notifyFailure>
+      <notifyBackToNormal>false</notifyBackToNormal>
+      <notifyRepeatedFailure>false</notifyRepeatedFailure>
+      <includeTestSummary>false</includeTestSummary>
+      <commitInfoChoice>NONE</commitInfoChoice>
+      <includeCustomMessage>false</includeCustomMessage>
+      <customMessage/>
+    </jenkins.plugins.slack.SlackNotifier>
+  </publishers>
+</project>

--- a/tests/publishers/fixtures/slack003.yaml
+++ b/tests/publishers/fixtures/slack003.yaml
@@ -1,0 +1,2 @@
+publishers:
+  - slack

--- a/tests/publishers/fixtures/slack004.plugins_info.yaml
+++ b/tests/publishers/fixtures/slack004.plugins_info.yaml
@@ -1,0 +1,3 @@
+- longName: 'Slack Notification Plugin'
+  shortName: 'slack'
+  version: "2.0"

--- a/tests/publishers/fixtures/slack004.xml
+++ b/tests/publishers/fixtures/slack004.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <publishers>
+    <jenkins.plugins.slack.SlackNotifier>
+      <teamDomain>teamname</teamDomain>
+      <authToken>yourauthtoken</authToken>
+      <buildServerUrl>http://localhost:8081</buildServerUrl>
+      <room>#builds</room>
+      <startNotification>true</startNotification>
+      <notifySuccess>true</notifySuccess>
+      <notifyAborted>true</notifyAborted>
+      <notifyNotBuilt>true</notifyNotBuilt>
+      <notifyUnstable>true</notifyUnstable>
+      <notifyFailure>true</notifyFailure>
+      <notifyBackToNormal>true</notifyBackToNormal>
+      <notifyRepeatedFailure>true</notifyRepeatedFailure>
+      <includeTestSummary>true</includeTestSummary>
+      <commitInfoChoice>AUTHORS_AND_TITLES</commitInfoChoice>
+      <includeCustomMessage>true</includeCustomMessage>
+      <customMessage>A custom message.</customMessage>
+    </jenkins.plugins.slack.SlackNotifier>
+  </publishers>
+</project>

--- a/tests/publishers/fixtures/slack004.yaml
+++ b/tests/publishers/fixtures/slack004.yaml
@@ -1,0 +1,18 @@
+publishers:
+  - slack:
+      team-domain: 'teamname'
+      auth-token: 'yourauthtoken'
+      build-server-url: 'http://localhost:8081'
+      room: '#builds'
+      notify-start: True
+      notify-success: True
+      notify-aborted: True
+      notify-not-built: True
+      notify-unstable: True
+      notify-failure: True
+      notify-back-to-normal: True
+      notify-repeated-failure: True
+      include-test-summary: True
+      commit-info-choice: 'AUTHORS_AND_TITLES'
+      include-custom-message: True
+      custom-message: 'A custom message.'


### PR DESCRIPTION
Right now, it's impossible to define things like `notify-failure: true` for Slack plugin. I cherry picked a [fix from upstream](https://github.com/openstack-infra/jenkins-job-builder/commit/31adb517214b0e2ae8a9b86eba1757afd51337da).

@ludwikkazmierczak @nikodamn 